### PR TITLE
Task-354 Active columns settings is saving to LocalStorage

### DIFF
--- a/src/pages/Products/ProductsPage.tsx
+++ b/src/pages/Products/ProductsPage.tsx
@@ -23,6 +23,23 @@ enum cols {
   notcall = 'Не передзвонювати',
 }
 
+let initialActiveColums: string[] = [
+  cols.id,
+  cols.mainImg,
+  cols.name,
+  cols.price,
+  cols.description,
+  cols.categoryName,
+  cols.key,
+  cols.files,
+  cols.createdAt,
+  cols.updatedAt,
+]
+
+if (localStorage.getItem('PRODUCTS_SETTINGS')) {
+    initialActiveColums = localStorage.getItem('PRODUCTS_SETTINGS')!.split(',')
+} 
+
 const Products: React.FC = () => {
   const location = useLocation();
   const history = useHistory();
@@ -31,19 +48,10 @@ const Products: React.FC = () => {
   const { list, loading, isSearch } = useProducts();
 
   const [showColumnsMenu, setShowColumnsMenu] = useState<boolean>(false);
-  const [activeColumns, setActiveColumns] = useState<string[]>([
-    cols.id,
-    cols.mainImg,
-    cols.name,
-    cols.price,
-    cols.description,
-    cols.categoryName,
-    cols.key,
-    cols.files,
-    cols.createdAt,
-    cols.updatedAt,
-  ]);
+  const [activeColumns, setActiveColumns] = useState<string[]>(initialActiveColums);
 
+  localStorage.setItem('PRODUCTS_SETTINGS', activeColumns.toString());
+  
   const handleColumns = (column: string) =>
     activeColumns.includes(column)
       ? setActiveColumns(activeColumns.filter((col) => col !== column))


### PR DESCRIPTION
Налаштування меню "Колонки" для категорії "Продукти" тепер не зникають після оновлення сторінки. Днанні зберігаються в LocalStorage як PRODUCTS_SETTINGS.